### PR TITLE
Allow setting zone temperature if device supports it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This integration is currently in beta. Please report any issues you find and any
 **⚠️ Make sure to read the 'Remarks' and 'Warning' sections**
 
 ## Features
-* Climate entity per device zone that allows you to control the operation mode and read the current temperature of the device/zone.
+* Climate entity per device zone that allows you to control the operation mode, read the current temperature of the water in the device/zone and (if the zone supports it), change the target temperature.
 * Sensor entity for the outdoor temperature.
-* Water heater entity for the hot water tank (if the device has one).
+* Water heater entity for the hot water tank (if the device has one), that allows you to control the operation mode (enabled/disabled) and read the current temperature of the water in the tank.
 * Diagnostic sensor to indicate if the device has any problem (such not enough water flow).
 
 ## Features in the works
@@ -22,8 +22,7 @@ This integration is currently in beta. Please report any issues you find and any
 * Weekly schedule.
 * Set the device in eco mode/quiet mode/holiday mode (if the device supports it).
 * Set the device in away mode (if the device supports it).
-* Investigate if it's possible to set target temperature for the zone on devices that support it.
-
+* Additional sensors/switches for the device.
 
 ## Remarks
 Panasonic only allows one connection per account at the same time. This means that if you open the session from the Panasonic Confort Cloud app or the Panasonic Confort Cloud website, the session will be closed and you will be disconnected from Home Assistant. The integration will try to reconnect automatically, clossing the session from the app or the website. If you want to use the app or the website, you will have to temporarily disable the integration.

--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 import aioaquarea
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
@@ -48,6 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN][entry.entry_id][CLIENT] = client
 
     try:
+        await client.login()
         # Get all the devices, we will filter the disabled ones later
         devices = await client.get_devices(include_long_id=True)
 

--- a/custom_components/aquarea/binary_sensor.py
+++ b/custom_components/aquarea/binary_sensor.py
@@ -1,7 +1,10 @@
+"""Diagnostics sensor that indicates if the Panasonic Aquarea Device is on error"""
 import logging
 
-from homeassistant.components.binary_sensor import (BinarySensorDeviceClass,
-                                                    BinarySensorEntity)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
@@ -25,15 +28,13 @@ async def async_setup_entry(
         config_entry.entry_id
     ][DEVICES]
 
-    entities: list[StatusBinarySensor] = []
-
-    entities.extend([StatusBinarySensor(coordinator) for coordinator in data.values()])
-
-    async_add_entities(entities)
+    async_add_entities(
+        [StatusBinarySensor(coordinator) for coordinator in data.values()]
+    )
 
 
 class StatusBinarySensor(AquareaBaseEntity, BinarySensorEntity):
-    """Representation of a Aquarea sensor."""
+    """Representation of a Aquarea sensor that indicates if the device is on error"""
 
     _attr_has_entity_name = True
 

--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -1,13 +1,14 @@
 """Config flow for Aquarea Smart Cloud integration."""
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 import aioaquarea
 import aiohttp
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult

--- a/custom_components/aquarea/coordinator.py
+++ b/custom_components/aquarea/coordinator.py
@@ -1,10 +1,11 @@
 """Coordinator for Aquarea."""
 from __future__ import annotations
 
-import logging
 from datetime import timedelta
+import logging
 
 import aioaquarea
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant

--- a/custom_components/aquarea/manifest.json
+++ b/custom_components/aquarea/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/cjaliaga/home-assistant-aquarea",
   "issue_tracker": "https://github.com/cjaliaga/home-assistant-aquarea/issues",
   "requirements": [
-    "aioaquarea==0.2.0"
+    "aioaquarea==0.3.0"
   ],
   "ssdp": [],
   "zeroconf": [],
@@ -20,5 +20,5 @@
     "@cjaliaga"
   ],
   "iot_class": "cloud_polling",
-  "version": "0.1.0a1"
+  "version": "0.1.0"
 }

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -1,7 +1,10 @@
 import logging
 
-from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
-                                             SensorStateClass)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
Closes #3 

If the device has an internal sensor for the specified climate zone, it will allow to change the target temperature of the zone.