### PR TITLE
Climate: Convert temperature to int as expected in Aquarea API

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -193,4 +193,6 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
                 str(temperature),
             )
 
-            await self.coordinator.device.set_temperature(temperature, zone.zone_id)
+            await self.coordinator.device.set_temperature(
+                int(temperature), zone.zone_id
+            )

--- a/custom_components/aquarea/manifest.json
+++ b/custom_components/aquarea/manifest.json
@@ -20,5 +20,5 @@
     "@cjaliaga"
   ],
   "iot_class": "cloud_polling",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }


### PR DESCRIPTION
Converting temperature from float to int as expected in the Panasonic API, allowing climate entities to set the zone temperature

#13 #9 #16 