### PR TITLE
Fix unique ids generation to support multiple devices and zones

### DIFF
--- a/custom_components/aquarea/binary_sensor.py
+++ b/custom_components/aquarea/binary_sensor.py
@@ -42,7 +42,7 @@ class StatusBinarySensor(AquareaBaseEntity, BinarySensorEntity):
         super().__init__(coordinator)
 
         self._attr_name = "Status"
-        self._attr_unique_id = f"{super()._attr_unique_id}_status"
+        self._attr_unique_id = f"{super().unique_id}_status"
         self._attr_device_class = BinarySensorDeviceClass.PROBLEM
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -107,7 +107,7 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         self._zone_id = zone_id
         self._attr_temperature_unit = TEMP_CELSIUS
         self._attr_name = device.zones.get(zone_id).name
-        self._attr_unique_id = f"{super()._attr_unique_id}_heatpump"
+        self._attr_unique_id = f"{super().unique_id}_climate_{zone_id}"
 
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -27,13 +27,9 @@ async def async_setup_entry(
         config_entry.entry_id
     ][DEVICES]
 
-    entities: list[OutDoorTemperatureSensor] = []
-
-    entities.extend(
+    async_add_entities(
         [OutDoorTemperatureSensor(coordinator) for coordinator in data.values()]
     )
-
-    async_add_entities(entities)
 
 
 class OutDoorTemperatureSensor(AquareaBaseEntity, SensorEntity):
@@ -45,7 +41,7 @@ class OutDoorTemperatureSensor(AquareaBaseEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_name = "Outdoor Temperature"
-        self._attr_unique_id = f"{super()._attr_unique_id}_outdoor_temperature"
+        self._attr_unique_id = f"{super().unique_id}_outdoor_temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "°C"

--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -38,17 +38,13 @@ async def async_setup_entry(
         config_entry.entry_id
     ][DEVICES]
 
-    entities: list[WaterHeater] = []
-
-    entities.extend(
+    async_add_entities(
         [
             WaterHeater(coordinator)
             for coordinator in data.values()
             if coordinator.device.has_tank
         ]
     )
-
-    async_add_entities(entities)
 
 
 class WaterHeater(AquareaBaseEntity, WaterHeaterEntity):
@@ -60,7 +56,7 @@ class WaterHeater(AquareaBaseEntity, WaterHeaterEntity):
         super().__init__(coordinator)
 
         self._attr_name = "Tank"
-        self._attr_unique_id = f"{super()._attr_unique_id}"
+        self._attr_unique_id = f"{super().unique_id}_tank"
         self._attr_temperature_unit = TEMP_CELSIUS
         self._attr_supported_features = (
             WaterHeaterEntityFeature.TARGET_TEMPERATURE


### PR DESCRIPTION
This fixes the unique id generation for entities as previously they were generated incorrectly. Adds support for installations with 2 zones (fixes #20) and accounts with more than 1 device, since the unique id is tied to the device guid.