### PR TITLE
Climate: Add precision attribute

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -17,7 +17,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -112,6 +112,8 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         self._attr_unique_id = f"{super().unique_id}_climate_{zone_id}"
 
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+
+        self._attr_precision = PRECISION_WHOLE
 
         self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
 


### PR DESCRIPTION
AFAIK, the supported temperature adjustment only supports full-degree jumps, not tenths of degrees.

According to the documentation, setting this attribute tells HASS exactly that :)

NB: This is my first contribution to a HASS (and to a Python) project. Please, bear with me if I did something totally wrong 😇 