### PR TITLE
Climate: Set HVAC mode when updating temp

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
+    ATTR_HVAC_MODE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
@@ -186,6 +187,10 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         """Set new target temperature if supported by the zone"""
         zone = self.coordinator.device.zones.get(self._zone_id)
         temperature: float | None = kwargs.get(ATTR_TEMPERATURE)
+        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
+
+        if hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
 
         if temperature is not None and zone.supports_set_temperature:
             _LOGGER.debug(

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -187,7 +187,7 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         """Set new target temperature if supported by the zone"""
         zone = self.coordinator.device.zones.get(self._zone_id)
         temperature: float | None = kwargs.get(ATTR_TEMPERATURE)
-        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
+        hvac_mode: HVACMode | None = kwargs.get(ATTR_HVAC_MODE)
 
         if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)


### PR DESCRIPTION
Resolves #50

It looks like `hvac_mode` is provided as part of the set temperature service: 
https://github.com/home-assistant/core/blob/9c0427a7acdf2e603eaab692250399b34be77fc2/homeassistant/components/climate/services.yaml#L68-L79