### PR TITLE
Bump aioaquarea to 0.3.8

### DIFF
--- a/custom_components/aquarea/manifest.json
+++ b/custom_components/aquarea/manifest.json
@@ -16,7 +16,7 @@
     "aquarea"
   ],
   "requirements": [
-    "aioaquarea==0.3.7"
+    "aioaquarea==0.3.8"
   ],
   "ssdp": [],
   "version": "0.2.4",


### PR DESCRIPTION
Bump aioaquarea to 0.3.8: https://github.com/cjaliaga/aioaquarea/releases/tag/v0.3.8