### PR TITLE
Climate: Using device quiet mode as preset modes

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, PRECISION_WHOLE
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -127,7 +127,7 @@ def get_preset_from_quiet_mode(quiet_mode: QuietMode) -> str:
 def get_presets() -> list[str]:
     """Return the list of available preset modes."""
     return [
-        "",
+        "Quiet Mode Off",
         "Quiet Mode Level 1",
         "Quiet Mode Level 2",
         "Quiet Mode Level 3",
@@ -149,7 +149,7 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         device = coordinator.device
 
         self._zone_id = zone_id
-        self._attr_temperature_unit = TEMP_CELSIUS
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_name = device.zones.get(zone_id).name
         self._attr_unique_id = f"{super().unique_id}_climate_{zone_id}"
 

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -8,6 +8,7 @@ from aioaquarea import (
     ExtendedOperationMode,
     OperationStatus,
     UpdateOperationMode,
+    QuietMode,
 )
 
 from homeassistant.components.climate import (
@@ -18,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, PRECISION_WHOLE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -93,6 +94,46 @@ def get_update_operation_mode_from_hvac_mode(mode: HVACMode) -> UpdateOperationM
     return UpdateOperationMode.OFF
 
 
+def get_quiet_mode_from_preset_mode(preset_mode: str) -> QuietMode:
+    """Convert preset mode to quiet mode."""
+
+    if preset_mode == "Quiet Mode Level 1":
+        return QuietMode.LEVEL1
+
+    if preset_mode == "Quiet Mode Level 2":
+        return QuietMode.LEVEL2
+
+    if preset_mode == "Quiet Mode Level 3":
+        return QuietMode.LEVEL3
+
+    return QuietMode.OFF
+
+
+def get_preset_from_quiet_mode(quiet_mode: QuietMode) -> str:
+    """Convert quiet mode to preset mode."""
+
+    if quiet_mode == QuietMode.LEVEL1:
+        return "Quiet Mode Level 1"
+
+    if quiet_mode == QuietMode.LEVEL2:
+        return "Quiet Mode Level 2"
+
+    if quiet_mode == QuietMode.LEVEL3:
+        return "Quiet Mode Level 3"
+
+    return ""
+
+
+def get_presets() -> list[str]:
+    """Return the list of available preset modes."""
+    return [
+        "",
+        "Quiet Mode Level 1",
+        "Quiet Mode Level 2",
+        "Quiet Mode Level 3",
+    ]
+
+
 class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
     """The ClimateEntity that controls one zone of the Aquarea heat pump.
     Some settings are shared between zones.
@@ -112,11 +153,13 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         self._attr_name = device.zones.get(zone_id).name
         self._attr_unique_id = f"{super().unique_id}_climate_{zone_id}"
 
-        self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
-
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        )
         self._attr_precision = PRECISION_WHOLE
-
         self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+        self._attr_preset_modes = get_presets()
+        self._attr_preset_mode = get_preset_from_quiet_mode(device.quiet_mode)
 
         if device.support_cooling(zone_id):
             self._attr_hvac_modes.extend([HVACMode.COOL, HVACMode.HEAT_COOL])
@@ -135,6 +178,8 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         self._attr_icon = (
             "mdi:hvac-off" if device.mode == ExtendedOperationMode.OFF else "mdi:hvac"
         )
+
+        self._attr_preset_mode = get_preset_from_quiet_mode(device.quiet_mode)
 
         self._attr_current_temperature = zone.temperature
 
@@ -205,3 +250,17 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
             await self.coordinator.device.set_temperature(
                 int(temperature), zone.zone_id
             )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode not in self.preset_modes:
+            raise ValueError(f"Unsupported preset mode: {preset_mode}")
+
+        _LOGGER.debug(
+            "Setting preset mode of %s to %s",
+            self.coordinator.device.device_id,
+            preset_mode,
+        )
+
+        quiet_mode = get_quiet_mode_from_preset_mode(preset_mode)
+        await self.coordinator.device.set_quiet_mode(quiet_mode)


### PR DESCRIPTION
Allows setting the device quiet mode as preset modes of the climate entity. In case we found more options that might qualify as preset modes we can study the way to go in the future.

Closes #57 