### PR TITLE
Bump aioaquarea to 0.4.0

### DIFF
--- a/custom_components/aquarea/manifest.json
+++ b/custom_components/aquarea/manifest.json
@@ -16,7 +16,7 @@
     "aquarea"
   ],
   "requirements": [
-    "aioaquarea==0.3.8"
+    "aioaquarea==0.4.0"
   ],
   "ssdp": [],
   "version": "0.3.0",


### PR DESCRIPTION
Bump aioaquarea to 0.4.0: https://github.com/cjaliaga/aioaquarea/releases/tag/v0.4.0