### PR TITLE
Energy consumption sensors

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -85,6 +85,7 @@ class AquareaBaseEntity(CoordinatorEntity[AquareaDataUpdateCoordinator]):
 
     coordinator: AquareaDataUpdateCoordinator
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: AquareaDataUpdateCoordinator) -> None:
         """Initialize entity."""
@@ -95,7 +96,6 @@ class AquareaBaseEntity(CoordinatorEntity[AquareaDataUpdateCoordinator]):
             "id": self.coordinator.device.device_id,
         }
         self._attr_unique_id = self.coordinator.device.device_id
-        self._attr_name = self.coordinator.device.name
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.device.device_id)},
             manufacturer=self.coordinator.device.manufacturer,

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -1,4 +1,4 @@
-"""Climate entity to control a zone for a Panasonic Aquarea Device"""
+"""Climate entity to control a zone for a Panasonic Aquarea Device."""
 from __future__ import annotations
 
 import logging
@@ -7,16 +7,16 @@ from aioaquarea import (
     DeviceAction,
     ExtendedOperationMode,
     OperationStatus,
-    UpdateOperationMode,
     QuietMode,
+    UpdateOperationMode,
 )
 
 from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
-    ATTR_HVAC_MODE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature

--- a/custom_components/aquarea/coordinator.py
+++ b/custom_components/aquarea/coordinator.py
@@ -11,11 +11,14 @@ from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt
 
 from .const import DOMAIN
 
 DEFAULT_SCAN_INTERVAL_SECONDS = 10
 SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL_SECONDS)
+CONSUMPTION_REFRESH_INTERVAL_MINUTES = 1
+CONSUMPTION_REFRESH_INTERVAL = timedelta(minutes=CONSUMPTION_REFRESH_INTERVAL_MINUTES)
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -51,11 +54,14 @@ class AquareaDataUpdateCoordinator(DataUpdateCoordinator):
         return self._device
 
     async def _async_update_data(self) -> None:
-        """Fetch data from Aquarea Smart Cloud Service"""
+        """Fetch data from Aquarea Smart Cloud Service."""
         try:
+            # We are not getting consumption data on the first refresh, we'll get it on the next ones
             if not self._device:
                 self._device = await self._client.get_device(
-                    device_info=self._device_info
+                    device_info=self._device_info,
+                    consumption_refresh_interval=CONSUMPTION_REFRESH_INTERVAL,
+                    timezone=dt.DEFAULT_TIME_ZONE,
                 )
             else:
                 await self.device.refresh_data()

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -134,7 +134,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     for coordinator in data.values():
-        entities.append(OutDoorTemperatureSensor(coordinator))
+        entities.append(OutdoorTemperatureSensor(coordinator))
         entities.extend(
             [
                 EnergyAccumulatedConsumptionSensor(description,coordinator)
@@ -211,10 +211,11 @@ class AquareaAccumulatedSensorExtraStoredData(AquareaSensorExtraStoredData):
         return data
 
 
-class OutDoorTemperatureSensor(AquareaBaseEntity, SensorEntity):
+class OutdoorTemperatureSensor(AquareaBaseEntity, SensorEntity):
     """Representation of a Aquarea sensor."""
 
     def __init__(self, coordinator: AquareaDataUpdateCoordinator) -> None:
+        """Initialize outdoor temperature sensor."""
         super().__init__(coordinator)
 
         self._attr_translation_key = "outdoor_temperature"

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -52,7 +52,7 @@ ACCUMULATED_ENERGY_SENSORS: list[AquareaEnergyConsumptionSensorDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         consumption_type=ConsumptionType.COOL,
-        exists_fn=lambda coordinator: coordinator.device.support_cooling()
+        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values())
     ),
     AquareaEnergyConsumptionSensorDescription(
         key="tank_accumulated_energy_consumption",
@@ -105,7 +105,7 @@ ENERGY_SENSORS: list[AquareaEnergyConsumptionSensorDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         consumption_type=ConsumptionType.COOL,
-        exists_fn=lambda coordinator: coordinator.device.support_cooling(),
+        exists_fn=lambda coordinator: any(zone.cool_mode for zone in coordinator.device.zones.values()),
         entity_registry_enabled_default=False
     ),
     AquareaEnergyConsumptionSensorDescription(

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -45,16 +45,6 @@ ACCUMULATED_ENERGY_SENSORS: list[AquareaEnergyConsumptionSensorDescription] = [
         consumption_type=ConsumptionType.HEAT,
     ),
     AquareaEnergyConsumptionSensorDescription(
-        key="tank_accumulated_energy_consumption",
-        translation_key = "tank_accumulated_energy_consumption",
-        name= "Tank Accumulated Consumption",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        consumption_type=ConsumptionType.WATER_TANK,
-        exists_fn=lambda coordinator: coordinator.device.has_tank
-    ),
-    AquareaEnergyConsumptionSensorDescription(
         key="cooling_accumulated_energy_consumption",
         translation_key="cooling_accumulated_energy_consumption",
         name= "Cooling Accumulated Consumption",
@@ -63,6 +53,16 @@ ACCUMULATED_ENERGY_SENSORS: list[AquareaEnergyConsumptionSensorDescription] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         consumption_type=ConsumptionType.COOL,
         exists_fn=lambda coordinator: coordinator.device.support_cooling()
+    ),
+    AquareaEnergyConsumptionSensorDescription(
+        key="tank_accumulated_energy_consumption",
+        translation_key = "tank_accumulated_energy_consumption",
+        name= "Tank Accumulated Consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        consumption_type=ConsumptionType.WATER_TANK,
+        exists_fn=lambda coordinator: coordinator.device.has_tank
     ),
     AquareaEnergyConsumptionSensorDescription(
         key="accumulated_energy_consumption",
@@ -217,7 +217,6 @@ class OutDoorTemperatureSensor(AquareaBaseEntity, SensorEntity):
     def __init__(self, coordinator: AquareaDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
 
-        self._attr_name = "Outdoor Temperature"
         self._attr_translation_key = "outdoor_temperature"
         self._attr_unique_id = f"{super().unique_id}_outdoor_temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -23,5 +23,36 @@
                 }
             }
         }
+    },
+    "entity": {
+      "sensor": {
+        "heating_accumulated_energy_consumption": {
+          "name": "Heating accumulated consumption"
+        },
+        "cooling_accumulated_energy_consumption": {
+          "name": "Cooling accumulated consumption"
+        },
+        "tank_accumulated_energy_consumption": {
+          "name": "Tank accumulated consumption"
+        },
+        "accumulated_energy_consumption": {
+          "name": "Accumulated consumption"
+        },
+        "heating_energy_consumption": {
+          "name": "Heating consumption"
+        },
+        "cooling_energy_consumption": {
+          "name": "Cooling consumption"
+        },
+        "tank_energy_consumption": {
+          "name": "Tank consumption"
+        },
+        "energy_consumption": {
+          "name": "Consumption"
+        },
+        "outdoor_temperature": {
+          "name": "Outdoor temperature"
+        }
+      }
     }
 }

--- a/custom_components/aquarea/translations/es.json
+++ b/custom_components/aquarea/translations/es.json
@@ -23,5 +23,36 @@
                 }
             }
         }
+    },
+    "entity": {
+      "sensor": {
+        "heating_accumulated_energy_consumption": {
+          "name": "Consumo acumulado calefacción"
+        },
+        "cooling_accumulated_energy_consumption": {
+          "name": "Consumo acumulado refrigeración"
+        },
+        "tank_accumulated_energy_consumption": {
+          "name": "Consumo acumulado calentador de agua"
+        },
+        "accumulated_energy_consumption": {
+          "name": "Consumo acumulado"
+        },
+        "heating_energy_consumption": {
+          "name": "Consumo calefacción"
+        },
+        "cooling_energy_consumption": {
+          "name": "Consumo refrigeración"
+        },
+        "tank_energy_consumption": {
+          "name": "Consumo acumulado calentador de agua"
+        },
+        "energy_consumption": {
+          "name": "Consumo"
+        },
+        "outdoor_temperature": {
+          "name": "Temperatura exterior"
+        }
+      }
     }
 }


### PR DESCRIPTION
Adding energy consumption sensors for the following aspects:

- [x] Total consumption
- [x] Water Tank consumption
- [x] Heating consumption
- [x] Cooling consumption

In 2 different flavors:

- **Accumulated**: Total increasing sensor that doesn't reset any cycle and continues accumulating.
- **Consumption per hour**: Total increasing sensor that resets the cycle when it has available data for the next hour. These ones come disabled by default, the recommendation is to use the accumulated ones if possible.

_Initial translations in English and Spanish for the entity names are included_

#1 
