### PR TITLE
Moved "Quiet Mode" from presets to its own select entity

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -23,6 +23,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.WATER_HEATER,
     Platform.SWITCH,
+    Platform.SELECT
 ]
 
 

--- a/custom_components/aquarea/select.py
+++ b/custom_components/aquarea/select.py
@@ -1,0 +1,76 @@
+"""Select entities for Aquarea integration."""
+import logging
+
+from aioaquarea import QuietMode
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AquareaBaseEntity
+from .const import DEVICES, DOMAIN
+from .coordinator import AquareaDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+QUIET_MODE_LOOKUP = {
+    "level1" : QuietMode.LEVEL1,
+    "level2" : QuietMode.LEVEL2,
+    "level3" : QuietMode.LEVEL3,
+    "off" : QuietMode.OFF
+}
+
+QUIET_MODE_REVERSE_LOOKUP = {v: k for k, v in QUIET_MODE_LOOKUP.items()}
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Aquarea select entities from config entry."""
+
+    data: dict[str, AquareaDataUpdateCoordinator] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][DEVICES]
+
+    entities: list[SelectEntity] = []
+
+    entities.extend([AquareaQuietModeSelect(coordinator) for coordinator in data.values()])
+
+    async_add_entities(entities)
+
+class AquareaQuietModeSelect(AquareaBaseEntity, SelectEntity):
+    """Representation of an Aquarea select entity to configure the device's quiet mode."""
+
+    def __init__(self, coordinator: AquareaDataUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+        self._attr_unique_id = f"{super().unique_id}_quiet_mode"
+        self._attr_translation_key = "quiet_mode"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_options = list(QUIET_MODE_LOOKUP.keys())
+        self._attr_icon = "mdi:volume-off"
+
+    @property
+    def current_option(self) -> str:
+        """The current select option."""
+        return QUIET_MODE_REVERSE_LOOKUP.get(self.coordinator.device.quiet_mode)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        if(quiet_mode := QUIET_MODE_LOOKUP.get(option)) is None:
+            return
+
+        if quiet_mode is self.coordinator.device.quiet_mode:
+            return
+
+        _LOGGER.debug(
+            "Setting Quiet Mode of device %s, from %s to %s",
+            self.coordinator.device.device_id,
+            str(self.coordinator.device.quiet_mode),
+            str(quiet_mode)
+        )
+        await self.coordinator.device.set_quiet_mode(quiet_mode)

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -67,6 +67,17 @@
           "name": "Outdoor temperature"
         }
       },
+      "select": {
+        "quiet_mode": {
+          "name": "Quiet mode",
+          "state": {
+            "level1": "Level 1",
+            "level2": "Level 2",
+            "level3": "Level 3",
+            "off": "Off"
+          }
+        }
+      },
       "switch": {
         "force_dhw": {
           "name": "Force DHW"

--- a/custom_components/aquarea/translations/es.json
+++ b/custom_components/aquarea/translations/es.json
@@ -67,6 +67,17 @@
           "name": "Temperatura exterior"
         }
       },
+      "select": {
+        "quiet_mode": {
+          "name": "Modo silencioso",
+          "state": {
+            "level1": "Nivel 1",
+            "level2": "Nivel 2",
+            "level3": "Nivel 3",
+            "off": "Apagado"
+          }
+        }
+      },
       "switch": {
         "force_dhw": {
           "name": "Forzar ACS"


### PR DESCRIPTION
This PR moves the quiet mode configuration from the climate presets to its own entity. This is in preparation for including the ECO and Confort modes as presets.

The entity category is configuration for the time being.